### PR TITLE
Add Mailpit configuration for development emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,21 @@ yarn
 
 Go to `./settings/` and copy `settings-development-example.json` to `settings-development.json` and modify the following:
 
-- **MAIL_URL:** Update the connection string according to your smtp credentials.
+- **MAIL_URL:** 
+
+For development environment.
+
+Install mailpit:
+````shell
+brew install mailpit
+````
+Open a separate terminal to run mailpit:
+````shell
+mailpit
+````
+
+For production environment:
+Update the connection string according to your smtp credentials.
 
 Running project
 ---------------

--- a/imports/startup/server/services/MailServ.ts
+++ b/imports/startup/server/services/MailServ.ts
@@ -1,5 +1,34 @@
 import { Meteor } from 'meteor/meteor';
 
+type MailpitSettings = {
+	HOST?: string;
+	PORT?: number;
+	USER?: string;
+	PASSWORD?: string;
+};
+
+const mailpitConfig: MailpitSettings | undefined = Meteor.settings.private?.MAILPIT;
+
+const getMailpitMailUrl = (config?: MailpitSettings) => {
+	if (!config?.HOST || !config?.PORT) return undefined;
+
+	const hasPassword = typeof config.PASSWORD === 'string' && config.PASSWORD.length > 0;
+	const hasUser = typeof config.USER === 'string' && config.USER.length > 0;
+
+	if (!hasUser) return `smtp://${ config.HOST }:${ config.PORT }`;
+
+	const encodedUser = encodeURIComponent(config.USER);
+	const encodedPassword = hasPassword ? encodeURIComponent(config.PASSWORD) : undefined;
+	const credentials = encodedPassword ? `${ encodedUser }:${ encodedPassword }@` : `${ encodedUser }@`;
+
+	return `smtp://${ credentials }${ config.HOST }:${ config.PORT }`;
+};
+
+const applyRootUrlFromSettings = () => {
+	const rootUrl = Meteor.settings.private?.ROOT_URL;
+	if (rootUrl) process.env.ROOT_URL = rootUrl;
+};
+
 if (Meteor.isDevelopment) {
 	if (Meteor.settings.private?.SENDER_EMAILS) {
 		process.env.EMAIL_SERVICES = Meteor.settings.private.SENDER_EMAILS.SERVICES;
@@ -74,9 +103,16 @@ emailTemplates.verifyEmail = {
 
 //Activate the service of Mails.
 if (Meteor.isDevelopment) {
-	if (Meteor.settings.private?.MAIL_URL) {
-		process.env.MAIL_URL = Meteor.settings.private.MAIL_URL;
-		process.env.ROOT_URL = Meteor.settings.private.ROOT_URL;
+	const mailpitMailUrl = getMailpitMailUrl(mailpitConfig);
+	const settingsMailUrl = Meteor.settings.private?.MAIL_URL;
+
+	if (mailpitMailUrl) {
+		process.env.MAIL_URL = mailpitMailUrl;
+		applyRootUrlFromSettings();
+		console.info(`[Scaffold] - Mailpit configured at ${ mailpitConfig?.HOST }:${ mailpitConfig?.PORT }`);
+	} else if (settingsMailUrl) {
+		process.env.MAIL_URL = settingsMailUrl;
+		applyRootUrlFromSettings();
 	} else {
 		console.warn('[Scaffold] - Email settings are not configured. Emails will not be sent. ');
 	}

--- a/imports/startup/server/services/MailServ.ts
+++ b/imports/startup/server/services/MailServ.ts
@@ -1,3 +1,4 @@
+import { Accounts } from 'meteor/accounts-base';
 import { Meteor } from 'meteor/meteor';
 
 type MailpitSettings = {
@@ -15,13 +16,13 @@ const getMailpitMailUrl = (config?: MailpitSettings) => {
 	const hasPassword = typeof config.PASSWORD === 'string' && config.PASSWORD.length > 0;
 	const hasUser = typeof config.USER === 'string' && config.USER.length > 0;
 
-	if (!hasUser) return `smtp://${ config.HOST }:${ config.PORT }`;
+	if (!hasUser) return `smtp://${config.HOST}:${config.PORT}`;
 
 	const encodedUser = encodeURIComponent(config.USER);
 	const encodedPassword = hasPassword ? encodeURIComponent(config.PASSWORD) : undefined;
-	const credentials = encodedPassword ? `${ encodedUser }:${ encodedPassword }@` : `${ encodedUser }@`;
+	const credentials = encodedPassword ? `${encodedUser}:${encodedPassword}@` : `${encodedUser}@`;
 
-	return `smtp://${ credentials }${ config.HOST }:${ config.PORT }`;
+	return `smtp://${credentials}${config.HOST}:${config.PORT}`;
 };
 
 const applyRootUrlFromSettings = () => {
@@ -38,13 +39,13 @@ if (Meteor.isDevelopment) {
 }
 
 const name = 'Scaffold';
-const email = `<${ process.env.EMAIL_SERVICES }>`;
-const from = `${ name } ${ email }`;
+const email = `<${process.env.EMAIL_SERVICES}>`;
+const from = `${name} ${email}`;
 const emailResetPassword = 'email_reset_password.html';
 const emailVerifyEmail = 'email_verify_email.html';
 const emailEnrollAccount = 'email_enroll_account.html';
 
-const productSrc = `${ process.env.ROOT_URL }/img/meteor-vue.png`;
+const productSrc = `${process.env.ROOT_URL}/img/meteor-vue.png`;
 
 Accounts.emailTemplates.siteName = name;
 Accounts.emailTemplates.from = from;
@@ -59,7 +60,7 @@ emailTemplates.resetPassword = {
 		const urlWithoutHash = url.replace('#/', '');
 		const emailResetPasswordTemplate = await Assets.getTextAsync(emailResetPassword);
 		SSR.compileTemplate('emailResetPassword', emailResetPasswordTemplate);
-		if (Meteor.isDevelopment) console.info(`Password reset link: ${ urlWithoutHash }`);
+		if (Meteor.isDevelopment) console.info(`Password reset link: ${urlWithoutHash}`);
 		return SSR.render('emailResetPassword', {
 			productSrc,
 			urlWithoutHash
@@ -70,11 +71,11 @@ emailTemplates.resetPassword = {
 // Enroll Account
 emailTemplates.enrollAccount = {
 	subject() {
-		return `Welcome to ${ name }`;
+		return `Welcome to ${name}`;
 	},
 	async html(_user: Meteor.User, url: string) {
 		const urlWithoutHash = url.replace('#/', '');
-		if (Meteor.isDevelopment) console.info(`Set initial password link: ${ urlWithoutHash }`);
+		if (Meteor.isDevelopment) console.info(`Set initial password link: ${urlWithoutHash}`);
 		const emailEnrollAccountTemplate = await Assets.getTextAsync(emailEnrollAccount);
 		SSR.compileTemplate('emailEnrollAccount', emailEnrollAccountTemplate);
 		return SSR.render('emailEnrollAccount', {
@@ -91,7 +92,7 @@ emailTemplates.verifyEmail = {
 	},
 	async html(_user: Meteor.User, url: string) {
 		const urlWithoutHash = url.replace('#/', '');
-		if (Meteor.isDevelopment) console.info(`Verify email link: ${ urlWithoutHash }`);
+		if (Meteor.isDevelopment) console.info(`Verify email link: ${urlWithoutHash}`);
 		const emailVerifyEmailTemplate = await Assets.getTextAsync(emailVerifyEmail);
 		SSR.compileTemplate('emailVerifyEmail', emailVerifyEmailTemplate);
 		return SSR.render('emailVerifyEmail', {
@@ -109,7 +110,7 @@ if (Meteor.isDevelopment) {
 	if (mailpitMailUrl) {
 		process.env.MAIL_URL = mailpitMailUrl;
 		applyRootUrlFromSettings();
-		console.info(`[Scaffold] - Mailpit configured at ${ mailpitConfig?.HOST }:${ mailpitConfig?.PORT }`);
+		console.info(`[Scaffold] - Mailpit configured at ${mailpitConfig?.HOST}:${mailpitConfig?.PORT}`);
 	} else if (settingsMailUrl) {
 		process.env.MAIL_URL = settingsMailUrl;
 		applyRootUrlFromSettings();

--- a/settings/settings-development-example.json
+++ b/settings/settings-development-example.json
@@ -2,6 +2,12 @@
   "private": {
     "ROOT_URL": "http://localhost:3000",
     "MAIL_URL": "smtp://user:password@smtp.gmail.com:587",
+    "MAILPIT": {
+      "HOST": "localhost",
+      "PORT": 1025,
+      "USER": "",
+      "PASSWORD": ""
+    },
     "MONGO_URL": "mongodb://localhost:27017/theory-swe",
     "REFRESH_PERMISSIONS": false,
     "REFRESH_STATIC_PROFILES": false,

--- a/tests/server/database/initializeDatabaseForTest.ts
+++ b/tests/server/database/initializeDatabaseForTest.ts
@@ -1,0 +1,43 @@
+import { Roles } from 'meteor/alanning:roles';
+import { Meteor } from 'meteor/meteor';
+import { Profile } from '/imports/api/Profiles/profile.entity';
+import { RefreshPermissionsBackfill } from '/imports/backfills/recurring/RefreshPermissionsBackfill';
+import { RefreshStaticProfilesBackfill } from '/imports/backfills/recurring/RefreshStaticProfilesBackfill';
+
+const getCollectionStates = async (): Promise<{ rolesEmpty: boolean; profilesEmpty: boolean }> => {
+    const [rolesCount, profilesCount] = await Promise.all([
+        Roles.getAllRoles().countAsync(),
+        Profile.collection.find({}).countAsync(),
+    ]);
+
+    return {
+        rolesEmpty: rolesCount === 0,
+        profilesEmpty: profilesCount === 0,
+    };
+};
+
+export const initializeDatabaseForTest = async (): Promise<void> => {
+    if (!Meteor.isServer) {
+        return;
+    }
+
+    const { rolesEmpty, profilesEmpty } = await getCollectionStates();
+
+    if (!rolesEmpty && !profilesEmpty) {
+        return;
+    }
+
+    if (rolesEmpty) {
+        await new RefreshPermissionsBackfill().run();
+    }
+
+    if (profilesEmpty) {
+        await new RefreshStaticProfilesBackfill().run();
+    }
+};
+
+before(async function () {
+    // max time for this hook, otherwise Mocha will abort as timeout.
+    this.timeout?.(20000);
+    await initializeDatabaseForTest();
+});

--- a/tests/server/main.ts
+++ b/tests/server/main.ts
@@ -1,6 +1,7 @@
+import './database/initializeDatabaseForTest';
+
 import './Factories/Users/UsersFactory.test';
 import './Factories/Profiles/ProfilesFactory.test';
 
 import './Users/UsersCtrl.test';
 import './Profiles/ProfilesCtrl.test';
-


### PR DESCRIPTION
## Summary
- add Mailpit configuration handling in MailServ to build SMTP URL from development settings
- ensure root URL is applied when configuring email delivery and log Mailpit usage
- document Mailpit sample settings in the development settings example

## Screenshots

<img width="1601" height="869" alt="image" src="https://github.com/user-attachments/assets/55e0dd54-9103-49db-863d-e8581952df15" />


## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940fab80d488331b6ca8eb278fe3a8b)