### PR TITLE
Update Docker setup for Meteor 3.3.2 and MongoDB 7

### DIFF
--- a/docker-compose.no-ssl.yml
+++ b/docker-compose.no-ssl.yml
@@ -23,26 +23,9 @@ services:
       - REFRESH_PERMISSIONS
       - EMAIL_SERVICES
     ports:
-    - 80:3000
+      - 80:3000
     volumes:
       - $PWD/.uploads:/opt/app-files
-    networks:
-      - scaffold-net
-  ssl-proxy:
-    container_name: ssl-proxy
-    image: justsml/ssl-proxy:latest
-    environment:
-      - HTTPS_PORT=443
-      - SERVER_NAME=antware.dev
-      - UPSTREAM_TARGET=app:3000
-      - CERT_PUBLIC_PATH=/certs/fullchain.pem
-      - CERT_PRIVATE_PATH=/certs/privkey.pem
-    volumes:
-      - /certs:/certs:ro
-    depends_on:
-      - app
-    ports:
-      - 443:443
     networks:
       - scaffold-net
   mongo-primary:

--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,5 @@
 # The tag here should match the Meteor version of your app, per .meteor/release
-FROM geoffreybooth/meteor-base:2.13.3
+FROM geoffreybooth/meteor-base:3.3.2
 
 # Copy app package.json and package-lock.json into container
 COPY ./package*.json $APP_SOURCE_FOLDER/
@@ -11,8 +11,8 @@ COPY . $APP_SOURCE_FOLDER/
 
 RUN bash $SCRIPTS_FOLDER/build-meteor-bundle.sh
 
-# Use the specific version of Node expected by your Meteor release, per https://docs.meteor.com/changelog.html; this is expected for Meteor 2.13.3
-FROM node:14.21.3-alpine3.17
+# Use the specific version of Node expected by your Meteor release, per https://docs.meteor.com/changelog.html; this is expected for Meteor 3.3.2
+FROM node:20.17.0-alpine3.20
 
 ENV APP_BUNDLE_FOLDER /opt/bundle
 ENV SCRIPTS_FOLDER /docker
@@ -35,7 +35,7 @@ RUN bash $SCRIPTS_FOLDER/build-meteor-npm-dependencies.sh --build-from-source
 
 # Start another Docker stage, so that the final image doesn’t contain the layer with the build dependencies
 # See previous FROM line; this must match
-FROM node:14.21.3-alpine3.17
+FROM node:20.17.0-alpine3.20
 
 ENV APP_BUNDLE_FOLDER /opt/bundle
 ENV SCRIPTS_FOLDER /docker

--- a/installDockerUbuntu16.sh
+++ b/installDockerUbuntu16.sh
@@ -1,9 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Update Docker installation steps for the latest Ubuntu release (24.04+)
 sudo apt-get update
-sudo apt-get install apt-transport-https ca-certificates curl software-properties-common -y
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+sudo apt-get install -y ca-certificates curl gnupg lsb-release
+
+# Configure Docker's official GPG key using the recommended keyring location
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+
+# Add the stable repository for the detected Ubuntu codename
+echo \
+  "deb [arch=\"$(dpkg --print-architecture)\" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  \"$(. /etc/os-release && echo \"$VERSION_CODENAME\")\" stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
 sudo apt-get update
-sudo apt-get install docker-ce -y
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
 sudo systemctl enable docker
-sudo usermod -aG docker $(whoami)
-echo "Installation of docker finished"
+sudo usermod -aG docker "$(whoami)"
+echo "Installation of Docker finished for the latest Ubuntu release."


### PR DESCRIPTION
## Summary
- refresh Ubuntu installation script to follow current Docker setup steps for the latest release
- align Docker image builds with the app’s Meteor 3.3.2 release and expected Node.js runtime
- bump MongoDB containers to version 7 and provide a non-SSL docker-compose variant

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69439b8cc6488331b0daee12340e8ba1)