### PR TITLE
docs(agents): add repo agent guidance

### DIFF
--- a/.agents/skills/commit-convention/SKILL.md
+++ b/.agents/skills/commit-convention/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: commit-convention
+description: Standardize commit message format and PR title using the project convention. Use when asked to format a commit, write a commit message, check commit convention, or format a Pull Request (PR) title.
+---
+
+Enforce the Gencise commit message and PR title convention. Applies to both `git commit -m` messages and GitHub PR titles.
+
+## Convention
+
+```
+action_type(scope): summary 
+```
+
+**Example:**
+```
+fix(docker): update rabbitmq service configuration [INFRA-36]
+```
+
+## Action types
+
+| Type | When to use |
+|------|-------------|
+| `feat` | A new feature |
+| `fix` | A regular bug fix |
+| `hotfix` | A critical / production fix |
+| `chore` | Maintenance task (update deps, config files, CI, etc.) |
+| `refactor` | Tech debt cleanup — no behavior change |
+| `docs` | Adding or updating documentation, TSDoc, conventions |
+
+## Scope
+
+The module or area being changed. Examples: `ingestion`, `users`, `emails`, `mailboxes`, `docker`, `api`, `auth`, `workers`, `ui`, `db`.
+
+Use the most specific relevant module. If multiple unrelated modules are touched, consider splitting the commit; if they're tightly coupled, pick the primary one.
+
+## Agent steps
+
+1. If the user provides a branch name or description, infer the action type and scope from context.
+2. Write the summary in **imperative mood**, lowercase, no period at the end (e.g. "add retry logic", not "Added retry logic.").
+3. Keep the full message under 72 characters when possible.
+4. Present the formatted message and ask the user to confirm before running `git commit`.
+
+## Applying to PR titles
+
+PR titles follow the same format. When formatting a PR title:
+- Use `gh pr edit --title "..."` to update an existing PR.
+- Use `gh pr create --title "..."` when creating a new one.
+
+## Examples
+
+```
+feat(ingestion): add document classification pipeline [TRANS-8]
+fix(emails): handle missing attachment headers [MAIL-22]
+hotfix(api): prevent null pointer on empty payload [SUPP-99]
+chore(docker): upgrade rabbitmq to 3.13 [INFRA-36]
+refactor(workers): extract retry logic into base class [TRANS-41]
+docs(auth): document OAuth flow in CONTRIBUTING.md [INFRA-10]
+```

--- a/.agents/skills/pr-address-comments/SKILL.md
+++ b/.agents/skills/pr-address-comments/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: pr-address-comments
+description: Address all unresolved review comments on a pull request. Use when asked to address PR comments, respond to review feedback, fix review notes, or resolve PR review threads.
+---
+
+Given a PR URL or number, fetch all unresolved review comments, address actionable ones in the code, commit and push, then reply to each thread with the commit link. Non-actionable comments get a 👎 reaction and a brief justification reply.
+
+## Agent steps
+
+### 1. Fetch the PR and its comments
+
+```bash
+# Get PR metadata
+gh pr view <PR_URL_OR_NUMBER> --json number,headRefName,baseRefName,headRepositoryOwner,headRepository,state
+
+# List all review threads (unresolved only)
+gh api repos/<owner>/<repo>/pulls/<number>/comments \
+  --jq '.[] | {id, path, line, body, user: .user.login, in_reply_to_id}'
+
+# Also fetch review-level comments (not inline)
+gh api repos/<owner>/<repo>/pulls/<number>/reviews \
+  --jq '.[] | select(.state == "CHANGES_REQUESTED") | {id, body, user: .user.login}'
+```
+
+### 2. Check out the correct branch
+
+```bash
+gh pr checkout <number>
+# Verify
+git branch --show-current
+```
+
+### 3. Classify each comment
+
+For each unresolved comment, decide:
+
+| Category | Criteria | Action |
+|----------|----------|--------|
+| **Actionable** | Points to a real code issue, style violation, logic bug, missing test, unclear naming | Fix in code |
+| **Nitpick / optional** | Reviewer says "nit:", "optional:", or similar | Fix if trivial (<5 min); otherwise reply with justification |
+| **Not applicable** | Comment is outdated, refers to deleted code, or is a question already answered | 👎 reaction + reply explaining why |
+| **Discussion** | Open-ended question without a clear action | Reply with an answer; no code change unless the answer implies one |
+
+### 4. Apply code fixes
+
+Make the code changes for all actionable comments. Group logically related fixes into a single commit where possible. For each fixed comment, note the file and line so you can reference it in the reply.
+
+### 5. Commit and push
+
+```bash
+git add <changed-files>
+git commit -m "fix(<scope>): address PR review comments"
+git push origin HEAD
+```
+
+Get the commit SHA immediately after pushing:
+```bash
+git rev-parse HEAD
+# → <sha>
+```
+
+Build the commit URL:
+```
+https://github.com/<owner>/<repo>/commit/<sha>
+```
+
+### 6. Reply to each thread
+
+For **fixed comments:**
+```bash
+gh api repos/<owner>/<repo>/pulls/<number>/comments \
+  --method POST \
+  --field body="Fixed in <commit-url>." \
+  --field in_reply_to=<comment_id>
+```
+
+For **not-applicable / irrelevant comments:**
+```bash
+# Add 👎 reaction
+gh api repos/<owner>/<repo>/pulls/comments/<comment_id>/reactions \
+  --method POST \
+  --field content="-1"
+
+# Reply with reason
+gh api repos/<owner>/<repo>/pulls/<number>/comments \
+  --method POST \
+  --field body="Not addressing this because: <reason>." \
+  --field in_reply_to=<comment_id>
+```
+
+### 7. Resolve threads (if you have write access)
+
+```bash
+# Use GraphQL to mark threads as resolved
+gh api graphql -f query='
+  mutation {
+    resolveReviewThread(input: {threadId: "<thread_node_id>"}) {
+      thread { isResolved }
+    }
+  }
+'
+```
+
+If thread resolution requires maintainer access, skip this step and note it to the user.
+
+## Constraints
+
+- **Prefer `gh` CLI over the GitHub MCP** for all operations (comments, reactions, diffs).
+- Never push directly to `main` or `master` — always work on the PR's head branch.
+- Do not squash or force-push unless the user explicitly asks.
+- If a comment references a ticket (e.g. "this should be in TRANS-42"), note it but don't auto-create subtasks.
+- If two comments conflict with each other, flag it to the user before making a change.
+- If the fix for a comment is non-trivial (would take significant effort or requires new context), reply explaining the scope and ask the user whether to proceed.
+
+## Summary output
+
+After completing all comments, report to the user:
+
+```
+## PR #<number> — Comments addressed
+
+✅ Fixed (<N> comments) → <commit-url>
+💬 Replied with justification (<N> comments)
+⏭ Skipped — user decision needed (<N> comments, listed below)
+
+### Needs your decision
+- [comment link] <comment excerpt> → <why it's unclear>
+```

--- a/.agents/skills/pr-description/SKILL.md
+++ b/.agents/skills/pr-description/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: pr-description
+description: Add or update a pull request description using the standard template. Use when asked to write a PR description, fill out a PR body, document a pull request, or update PR details.
+---
+
+Generate and apply a structured PR description based on the changes in the branch. Uses `gh` CLI to fetch diff context and update the PR body.
+
+## Template
+
+```markdown
+## What?
+- <summary of what was implemented, derived from the diff>
+
+## Why?
+- <reason this change is necessary — usually the ticket goal>
+
+## Testing
+- <steps to reproduce the flow covered by this PR>
+
+## Screenshots
+<!-- Add any relevant screenshots here -->
+```
+
+## Agent steps
+
+1. **Identify the PR.** If the user provides a PR URL or number, use it. Otherwise run:
+   ```bash
+   gh pr view --json number,title,headRefName,baseRefName,body
+   ```
+
+2. **Get the diff and commit log** to understand what changed:
+   ```bash
+   gh pr diff
+   gh pr view --json commits --jq '.commits[].messageHeadline'
+   ```
+
+3. **Draft each section:**
+   - **What?** — bullet list of the main changes (features added, bugs fixed, configs updated). Derive from the diff, not just the commit messages. Be specific.
+   - **Why?** — the motivation. If a Jira ticket ID is available, state the ticket goal. If the user provides context, use it.
+   - **Testing** — numbered steps a reviewer can follow to verify the change locally. Include setup if needed (env vars, seed data, specific endpoints to hit).
+   - **Screenshots** — leave the placeholder as-is unless the user provides images.
+
+4. **Show the draft to the user** and ask for confirmation or edits before applying.
+
+5. **Apply the description:**
+   ```bash
+   gh pr edit <number> --body "$(cat <<'EOF'
+   <formatted body>
+   EOF
+   )"
+   ```
+
+## Constraints
+
+- Prefer `gh` CLI over any GitHub MCP tool.
+- Do not invent ticket goals — use the diff and any context the user provides.
+- Keep bullet points concise (one idea per bullet).
+- Testing steps must be actionable — avoid vague entries like "test the feature."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# AGENTS
+
+## App Overview
+
+- `theory-swe` is a Meteor 3 application with a Vue 3 + Vuetify frontend and MongoDB backing store.
+- The app covers authentication, users, permissions/profiles, email flows, and digital signature features.
+- Server code is TypeScript and the project uses Meteor's full-app runtime rather than a split SPA/API deployment.
+
+## Stack
+
+- Runtime: Node.js 22+, Meteor 3.3.x
+- Package manager: Yarn 1.x
+- Frontend: Vue 3, Vuetify, Pinia, Vue Router
+- Backend: Meteor, routing-controllers, MongoDB
+- Tests: Mocha via `meteor test`
+- Build tooling: TypeScript, Rspack, Sass
+
+## Common Commands
+
+- Install dependencies: `yarn`
+- Start locally: `yarn start`
+- Start with debugger: `yarn start:debug`
+- Run tests: `yarn test`
+- Run tests in watch mode: `yarn test:watch`
+- Run a backfill: `yarn backfill <BackfillName>`
+- Run seed data: `yarn seed`
+
+## Local Environment
+
+- Default local MongoDB: `mongodb://localhost:27017/theory-swe`
+- Meteor settings file: `settings/settings-development.json`
+- Example settings template: `settings/settings-development-example.json`
+- Mail development commonly uses Mailpit; `MAIL_URL` and the `private.MAILPIT` block live in the settings file.
+
+## Repo Layout
+
+- `client/`: Meteor client entrypoint
+- `server/`: Meteor server entrypoint
+- `imports/api/`: domain/server modules such as `Authentication`, `Users`, `Permissions`, `Profiles`, and `DigitalSignature`
+- `imports/ui/`: Vue UI, routes, stores, layouts, and shared frontend components
+- `imports/startup/`: Meteor startup wiring for client/server/both
+- `imports/backfills/`: one-off and recurring backfill jobs
+- `imports/seeders/`: seed data scripts
+- `tests/server/`: server-side test suites organized by domain
+- `scripts/`: helper scripts used by package commands
+- `settings/`: local development settings templates
+
+## Working Notes For Agents
+
+- Prefer narrow, domain-scoped changes. Most business logic is organized under `imports/api/<Domain>`.
+- Keep frontend work aligned with the existing Vue/Vuetify patterns under `imports/ui/`.
+- When adding tests, place them in the matching domain directory under `tests/server/`.
+- This repo may contain unrelated work in progress. Check `git status` before staging and avoid bundling unrelated files into a commit or PR.
+- For environment-sensitive changes, verify whether the behavior is configured through Meteor settings before hardcoding values.


### PR DESCRIPTION
## What?
- add a root `AGENTS.md` with stack, commands, repo layout, and working guidance for agents
- add local skills under `.agents/skills` for commit conventions, PR descriptions, and addressing PR review comments

## Why?
- document the repository context an agent needs to work safely in this Meteor/Vue codebase
- keep reusable agent workflows versioned inside the repository

## Testing
1. Review `AGENTS.md` for accuracy against `README.md`, `package.json`, and `settings/settings-development-example.json`
2. Confirm the PR only contains `.agents/*` and `AGENTS.md`

## Screenshots
<!-- Add any relevant screenshots here -->